### PR TITLE
Fix behaviour of FileMode.Create and .CreateNew

### DIFF
--- a/DirectoryPackage/DirectoryPackage.cs
+++ b/DirectoryPackage/DirectoryPackage.cs
@@ -44,13 +44,19 @@ namespace PackagingExtras.Directory
          if (path == null)
             throw new ArgumentNullException("path");
 
+         if (mode != FileMode.CreateNew && mode != FileMode.Create && mode != FileMode.Open && mode != FileMode.OpenOrCreate)
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+         if (mode == FileMode.CreateNew && System.IO.Directory.Exists(path))
+            throw new IOException("Directory already exists at " + path);
+
          if (mode == FileMode.Create && System.IO.Directory.Exists(path))
-            throw new DirectoryNotFoundException("Directory already exists at " + path);
+            System.IO.Directory.Delete(path, recursive: true); // in lack of a fast .NET API for cleaning, we just drop it and recreate it below
 
          if (mode == FileMode.Open && !System.IO.Directory.Exists(path))
             throw new DirectoryNotFoundException("Can't find package at " + path);                  
 
-         if (mode == FileMode.Create || mode == FileMode.OpenOrCreate)
+         if (mode == FileMode.CreateNew || mode == FileMode.Create || mode == FileMode.OpenOrCreate)
          {
             if (!System.IO.Directory.Exists(path))
                System.IO.Directory.CreateDirectory(path);


### PR DESCRIPTION
Previously, `FileMode.CreateNew` was not handled and `FileMode.Create` behaved like .CreateNew should behave. This commit brings the behaviour back in sync with the docs of FileMode. This also ensures equal semantics of `Package.Open` and `new DirectoryPackage` regarding the mode.

Note that this is a breaking change. However, as far as I see DirectoryPackage never had an official release, so this may not be a big concern. The effects are subtitle, though.